### PR TITLE
feat: add explicit data format argument to file IO functions

### DIFF
--- a/.serena/memories/docstring_fixes_session.md
+++ b/.serena/memories/docstring_fixes_session.md
@@ -1,0 +1,28 @@
+# Docstring Fixes Session
+
+## Task
+Updated docstrings across the serdeio codebase to match the actual API function signatures.
+
+## Changes Made
+
+### src/write.rs
+- `write_record_to_writer`: Fixed example argument order from `(writer, DataFormat, record)` to `(writer, record, DataFormat)`
+- `write_records_to_writer`: Fixed example argument order from `(writer, DataFormat, records)` to `(writer, records, DataFormat)`
+- `write_record_to_file`: Added missing `DataFormat::Auto` argument and `DataFormat` import to docstring examples
+- `write_records_to_file`: Added missing `DataFormat::Auto` argument and `DataFormat` import to docstring examples
+
+### src/read.rs
+- `read_record_from_file`: Added missing `DataFormat::Auto` argument and `DataFormat` import to docstring examples
+- `read_records_from_file`: Added missing `DataFormat::Auto` argument and `DataFormat` import to docstring examples
+
+### README.md
+- Fixed `read_records_from_file` call to include `DataFormat::Auto` argument
+- Fixed `write_records_to_writer` argument order to match API: `(writer, records, DataFormat)`
+
+## Verification
+- All 10 doc tests pass: `cargo test --doc`
+- Code passes linting: `cargo clippy -- -D warnings`
+- Code formatted: `cargo fmt`
+
+## Key Insight
+The file-based functions (`*_from_file` and `*_to_file`) take 3 arguments: `(path, data, data_format?)` where `data_format` defaults to `Auto` if not provided. The writer functions (`*_to_writer` and `*_from_reader`) take the data format as the last argument, not the middle.

--- a/README.md
+++ b/README.md
@@ -61,18 +61,18 @@ cargo add serdeio --features csv,yaml
 SerdeIO provides 8 main functions for reading and writing data:
 
 **Reader-based functions:**
-- `read_record_from_reader<T>(reader, format)` - Read a single record from any `Read` implementation
-- `read_records_from_reader<T>(reader, format)` - Read multiple records as `Vec<T>` from any `Read`
-- `write_record_to_writer<T>(writer, format, record)` - Write a single record to any `Write`
-- `write_records_to_writer<T>(writer, format, records)` - Write multiple records using an iterator
+- `read_record_from_reader<T>(reader, data_format)` - Read a single record from any `Read` implementation
+- `read_records_from_reader<T>(reader, data_format)` - Read multiple records as `Vec<T>` from any `Read`
+- `write_record_to_writer<T>(writer, record, data_format)` - Write a single record to any `Write`
+- `write_records_to_writer<T>(writer, records, data_format)` - Write multiple records using an iterator
 
 **File-based functions:**
-- `read_record_from_file<T>(path)` - Read a single record, auto-detecting format from file extension
-- `read_records_from_file<T>(path)` - Read multiple records, auto-detecting format from file extension
-- `write_record_to_file<T>(path, record)` - Write a single record, auto-detecting format from file extension
-- `write_records_to_file<T, I: IntoIterator<Item=&T>>(path, records)` - Write multiple records, accepts any iterator or collection (slices, Vec, iterators)
+- `read_record_from_file<T>(path, data_format?)` - Read a single record, auto-detecting format from file extension
+- `read_records_from_file<T>(path, data_format?)` - Read multiple records, auto-detecting format from file extension
+- `write_record_to_file<T>(path, record, data_format?)` - Write a single record, auto-detecting format from file extension
+- `write_records_to_file<T>(path, records, data_format?)` - Write multiple records, accepts any iterator or collection
 
-Note: Some formats like CSV and JSON Lines only support multiple records (`Vec<T>`).
+Note: Some formats like CSV and JSON Lines only support multiple records (`Vec<T>`). File-based functions accept an optional `DataFormat` override; if not provided or set to `Auto`, the format is inferred from the file extension.
 
 # Examples
 
@@ -97,12 +97,12 @@ pub fn main() -> AnyResult<()> {
     let input_file_path = "examples/users.json";
 
     // Read JSON file to memory (format auto-detected from .json extension)
-    let users: Vec<User> = read_records_from_file(input_file_path)
+    let users: Vec<User> = read_records_from_file(input_file_path, DataFormat::Auto)
         .context("Failed to read records from file")?;
 
     // Write to stdout in JSON Lines format
     let writer = std::io::stdout();
-    write_records_to_writer(writer, DataFormat::JsonLines, users.iter())?;
+    write_records_to_writer(writer, users.iter(), DataFormat::JsonLines)?;
 
     Ok(())
 }

--- a/examples/json2jsonl.rs
+++ b/examples/json2jsonl.rs
@@ -15,12 +15,12 @@ pub fn main() -> AnyResult<()> {
     let input_file_path = &args[1];
 
     // read json to memory
-    let users: Vec<User> =
-        read_record_from_file(input_file_path).context("Failed to read records from file")?;
+    let users: Vec<User> = read_record_from_file(input_file_path, DataFormat::Auto)
+        .context("Failed to read records from file")?;
 
     // write to stdout in json lines format
     let writer = std::io::stdout();
-    write_records_to_writer(writer, DataFormat::JsonLines, &users).unwrap();
+    write_records_to_writer(writer, &users, DataFormat::JsonLines).unwrap();
 
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {
+    #[error("Auto data format is not supported for this operation")]
+    AutoNotSupported,
     #[error("Data format error: {0}")]
     DataFormat(#[from] crate::types::DataFormatError),
     #[error("Unsupported file format: {0}")]

--- a/src/read.rs
+++ b/src/read.rs
@@ -142,7 +142,7 @@ fn open_file(path: impl AsRef<Path>) -> Result<(DataFormat, BufReader<File>), Er
 ///
 /// ```rust,no_run
 /// use serde::{Deserialize, Serialize};
-/// use serdeio::read_record_from_file;
+/// use serdeio::{read_record_from_file, DataFormat};
 ///
 /// #[derive(Deserialize)]
 /// struct User {
@@ -150,7 +150,7 @@ fn open_file(path: impl AsRef<Path>) -> Result<(DataFormat, BufReader<File>), Er
 ///     age: u32,
 /// }
 ///
-/// let user: User = read_record_from_file("user.json").unwrap();
+/// let user: User = read_record_from_file("user.json", DataFormat::Auto).unwrap();
 /// ```
 pub fn read_record_from_file<T: DeserializeOwned>(
     path: impl AsRef<Path>,
@@ -184,7 +184,7 @@ pub fn read_record_from_file<T: DeserializeOwned>(
 ///
 /// ```rust,no_run
 /// use serde::{Deserialize, Serialize};
-/// use serdeio::read_records_from_file;
+/// use serdeio::{read_records_from_file, DataFormat};
 ///
 /// #[derive(Deserialize)]
 /// struct User {
@@ -192,7 +192,7 @@ pub fn read_record_from_file<T: DeserializeOwned>(
 ///     age: u32,
 /// }
 ///
-/// let users: Vec<User> = read_records_from_file("users.json").unwrap();
+/// let users: Vec<User> = read_records_from_file("users.json", DataFormat::Auto).unwrap();
 /// ```
 pub fn read_records_from_file<T: DeserializeOwned>(
     path: impl AsRef<Path>,

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,6 +26,7 @@ use thiserror::Error;
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum DataFormat {
+    Auto,
     Json,
     JsonLines,
     #[cfg(feature = "csv")]
@@ -83,6 +84,7 @@ impl TryFrom<&Path> for DataFormat {
 impl Display for DataFormat {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            DataFormat::Auto => write!(f, "auto"),
             DataFormat::Json => write!(f, "json"),
             DataFormat::JsonLines => write!(f, "jsonl"),
             #[cfg(feature = "csv")]

--- a/src/write.rs
+++ b/src/write.rs
@@ -154,14 +154,16 @@ pub fn write_records_to_writer<'a, T: Serialize + 'a>(
 pub fn write_record_to_file<T: Serialize>(
     path: impl AsRef<Path>,
     record: &T,
-    mut data_format: DataFormat,
+    data_format: DataFormat,
 ) -> Result<(), Error> {
-    let inferred_format = DataFormat::try_from(path.as_ref())?;
-    if data_format == DataFormat::Auto {
-        data_format = inferred_format;
-    }
+    let path = path.as_ref();
+    let final_format = if data_format == DataFormat::Auto {
+        DataFormat::try_from(path)?
+    } else {
+        data_format
+    };
     let file = File::create(path)?;
-    write_record_to_writer(file, record, data_format)
+    write_record_to_writer(file, record, final_format)
 }
 
 /// Writes multiple records to a file in the data format inferred from the file extension.
@@ -202,12 +204,54 @@ pub fn write_record_to_file<T: Serialize>(
 pub fn write_records_to_file<'a, T: Serialize + 'a, I: IntoIterator<Item = &'a T>>(
     path: impl AsRef<Path>,
     records: I,
-    mut data_format: DataFormat,
+    data_format: DataFormat,
 ) -> Result<(), Error> {
-    let inferred_format = DataFormat::try_from(path.as_ref())?;
-    if data_format == DataFormat::Auto {
-        data_format = inferred_format;
-    }
+    let path = path.as_ref();
+    let final_format = if data_format == DataFormat::Auto {
+        DataFormat::try_from(path)?
+    } else {
+        data_format
+    };
     let file = File::create(path)?;
-    write_records_to_writer(file, records, data_format)
+    write_records_to_writer(file, records, final_format)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    #[derive(Serialize)]
+    struct TestRecord {
+        name: String,
+        value: i32,
+    }
+
+    #[test]
+    fn test_write_record_to_writer_auto_not_supported() {
+        let record = TestRecord {
+            name: "test".to_string(),
+            value: 42,
+        };
+        let mut buffer = Vec::new();
+        let result = write_record_to_writer(&mut buffer, &record, DataFormat::Auto);
+        assert!(matches!(result, Err(Error::AutoNotSupported)));
+    }
+
+    #[test]
+    fn test_write_records_to_writer_auto_not_supported() {
+        let records = vec![
+            TestRecord {
+                name: "test1".to_string(),
+                value: 1,
+            },
+            TestRecord {
+                name: "test2".to_string(),
+                value: 2,
+            },
+        ];
+        let mut buffer = Vec::new();
+        let result = write_records_to_writer(&mut buffer, &records, DataFormat::Auto);
+        assert!(matches!(result, Err(Error::AutoNotSupported)));
+    }
 }

--- a/src/write.rs
+++ b/src/write.rs
@@ -36,7 +36,7 @@ use crate::{Error, backend, types::DataFormat};
 ///
 /// let user = User { name: "Alice".to_string(), age: 30 };
 /// let mut buffer = Vec::new();
-/// write_record_to_writer(&mut buffer, DataFormat::Json, &user).unwrap();
+/// write_record_to_writer(&mut buffer, &user, DataFormat::Json).unwrap();
 /// let json = String::from_utf8(buffer).unwrap();
 /// assert!(json.contains("Alice"));
 /// ```
@@ -94,7 +94,7 @@ pub fn write_record_to_writer<T: Serialize>(
 ///     User { name: "Bob".to_string(), age: 25 },
 /// ];
 /// let mut buffer = Vec::new();
-/// write_records_to_writer(&mut buffer, DataFormat::Json, &users).unwrap();
+/// write_records_to_writer(&mut buffer, &users, DataFormat::Json).unwrap();
 /// let json = String::from_utf8(buffer).unwrap();
 /// assert!(json.contains("Alice") && json.contains("Bob"));
 /// ```
@@ -140,7 +140,7 @@ pub fn write_records_to_writer<'a, T: Serialize + 'a>(
 ///
 /// ```rust,no_run
 /// use serde::{Deserialize, Serialize};
-/// use serdeio::write_record_to_file;
+/// use serdeio::{write_record_to_file, DataFormat};
 ///
 /// #[derive(Serialize)]
 /// struct User {
@@ -149,7 +149,7 @@ pub fn write_records_to_writer<'a, T: Serialize + 'a>(
 /// }
 ///
 /// let user = User { name: "Alice".to_string(), age: 30 };
-/// write_record_to_file("user.json", &user).unwrap();
+/// write_record_to_file("user.json", &user, DataFormat::Auto).unwrap();
 /// ```
 pub fn write_record_to_file<T: Serialize>(
     path: impl AsRef<Path>,
@@ -185,7 +185,7 @@ pub fn write_record_to_file<T: Serialize>(
 ///
 /// ```rust,no_run
 /// use serde::{Deserialize, Serialize};
-/// use serdeio::write_records_to_file;
+/// use serdeio::{write_records_to_file, DataFormat};
 ///
 /// #[derive(Serialize)]
 /// struct User {
@@ -197,7 +197,7 @@ pub fn write_record_to_file<T: Serialize>(
 ///     User { name: "Alice".to_string(), age: 30 },
 ///     User { name: "Bob".to_string(), age: 25 },
 /// ];
-/// write_records_to_file("users.json", &users).unwrap();
+/// write_records_to_file("users.json", &users, DataFormat::Auto).unwrap();
 /// ```
 pub fn write_records_to_file<'a, T: Serialize + 'a, I: IntoIterator<Item = &'a T>>(
     path: impl AsRef<Path>,


### PR DESCRIPTION
closes #19 
This pull request updates the serdeio codebase to clarify and standardize how the `DataFormat` argument is handled across all read/write functions. It introduces a new `DataFormat::Auto` variant to allow file-based functions to auto-detect the format from the file extension, while explicitly disallowing `Auto` for reader/writer-based functions. The documentation, examples, and function signatures are updated to reflect these changes, and an appropriate error is returned if `Auto` is used incorrectly.

**API changes and error handling:**

* Added `DataFormat::Auto` as a new variant to the `DataFormat` enum, allowing file-based functions to auto-detect the format from the file extension.
* Updated reader/writer-based functions (`read_record_from_reader`, `read_records_from_reader`, `write_record_to_writer`, `write_records_to_writer`) to return a new `Error::AutoNotSupported` if `DataFormat::Auto` is passed, enforcing correct usage. [[1]](diffhunk://#diff-97e25e2a0e41c578875856e97b659be2719a65227c104b992e3144efa000c35eR5-R6) [[2]](diffhunk://#diff-f5613ff66dd29a0567e4173ff7c04ed28b08eb7384040946dd410698700b87eeR51) [[3]](diffhunk://#diff-f5613ff66dd29a0567e4173ff7c04ed28b08eb7384040946dd410698700b87eeR104) [[4]](diffhunk://#diff-8e31462ea4b11fdadc15fd98e895c1902595d9d34947c58eecca1125a5e6224dL39-R49) [[5]](diffhunk://#diff-8e31462ea4b11fdadc15fd98e895c1902595d9d34947c58eecca1125a5e6224dL96-R107)
* Modified file-based functions to accept an explicit `DataFormat` argument (defaulting to `Auto`), and to infer the format from the file extension if `Auto` is provided. [[1]](diffhunk://#diff-f5613ff66dd29a0567e4173ff7c04ed28b08eb7384040946dd410698700b87eeL143-R162) [[2]](diffhunk://#diff-f5613ff66dd29a0567e4173ff7c04ed28b08eb7384040946dd410698700b87eeL179-R204) [[3]](diffhunk://#diff-8e31462ea4b11fdadc15fd98e895c1902595d9d34947c58eecca1125a5e6224dL150-R164) [[4]](diffhunk://#diff-8e31462ea4b11fdadc15fd98e895c1902595d9d34947c58eecca1125a5e6224dL191-R212)

**Documentation and example updates:**

* Updated all docstrings and README examples to use the correct argument order and to include the `DataFormat` parameter where necessary, ensuring consistency with the actual API. [[1]](diffhunk://#diff-2a57b27004cbc3325c4abe189b5ca4615b36088c9f68386339d9671920290293R1-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R75) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L100-R105) [[4]](diffhunk://#diff-6666b8e40b7e69ad56034110fc02f603f8c2c0f324246a6d475ce9a8ccfdc216L18-R23) [[5]](diffhunk://#diff-8e31462ea4b11fdadc15fd98e895c1902595d9d34947c58eecca1125a5e6224dL141-R143) [[6]](diffhunk://#diff-8e31462ea4b11fdadc15fd98e895c1902595d9d34947c58eecca1125a5e6224dL179-R188)
* Clarified in documentation that file-based functions accept an optional `DataFormat` override, and that reader/writer-based functions always require an explicit format. [[1]](diffhunk://#diff-2a57b27004cbc3325c4abe189b5ca4615b36088c9f68386339d9671920290293R1-R28) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R75)

**Other improvements:**

* Implemented `Display` for `DataFormat::Auto` for improved error messages and debugging output.