### PR TITLE
fix: MessagePack round-trip, resolve_format dedup, example fix, TOML doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ Cargo.lock
 
 /target
 /Cargo.lock
+
+# Tool and generation artifacts
+.codegraph/
+.plan/
+.todos/

--- a/examples/json2jsonl.rs
+++ b/examples/json2jsonl.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result as AnyResult};
 use serde::{Deserialize, Serialize};
-use serdeio::{DataFormat, read_record_from_file, write_records_to_writer};
+use serdeio::{DataFormat, read_records_from_file, write_records_to_writer};
 
 #[derive(Debug, Deserialize, Serialize)]
 struct User {
@@ -15,7 +15,7 @@ pub fn main() -> AnyResult<()> {
     let input_file_path = &args[1];
 
     // read json to memory
-    let users: Vec<User> = read_record_from_file(input_file_path, DataFormat::Auto)
+    let users: Vec<User> = read_records_from_file(input_file_path, DataFormat::Auto)
         .context("Failed to read records from file")?;
 
     // write to stdout in json lines format

--- a/src/read.rs
+++ b/src/read.rs
@@ -81,11 +81,6 @@ pub fn read_record_from_reader<T: DeserializeOwned>(
 /// - YAML (requires `yaml` feature, as an array)
 /// - MessagePack (requires `messagepack` feature, as an array)
 ///
-/// # Note
-///
-/// TOML is not supported for multi-record operations. The TOML specification
-/// requires the root to be a table, so a bare array of records is not
-/// representable. Use the single-record TOML functions instead.
 /// # Errors
 ///
 /// Returns an error if the data format is not supported for multiple records,
@@ -110,6 +105,12 @@ pub fn read_record_from_reader<T: DeserializeOwned>(
 /// let users: Vec<User> = read_records_from_reader(reader, DataFormat::Json).unwrap();
 /// assert_eq!(users.len(), 2);
 /// ```
+///
+/// # Note
+///
+/// TOML is not supported for multi-record operations. The TOML specification
+/// requires the root to be a table, so a bare array of records is not
+/// representable. Use the single-record TOML functions instead.
 pub fn read_records_from_reader<T: DeserializeOwned>(
     reader: impl Read,
     data_format: DataFormat,

--- a/src/read.rs
+++ b/src/read.rs
@@ -6,16 +6,10 @@ use std::{
 
 use serde::de::DeserializeOwned;
 
-use crate::{Error, backend, types::DataFormat};
-
-fn resolve_format(path: impl AsRef<Path>, data_format: DataFormat) -> Result<DataFormat, Error> {
-    let path_ref = path.as_ref();
-    if data_format == DataFormat::Auto {
-        Ok(DataFormat::try_from(path_ref)?)
-    } else {
-        Ok(data_format)
-    }
-}
+use crate::{
+    Error, backend,
+    types::{DataFormat, resolve_format},
+};
 
 fn open_buf_reader(path: impl AsRef<Path>) -> Result<BufReader<File>, Error> {
     let file = File::open(path.as_ref())?;
@@ -87,6 +81,11 @@ pub fn read_record_from_reader<T: DeserializeOwned>(
 /// - YAML (requires `yaml` feature, as an array)
 /// - MessagePack (requires `messagepack` feature, as an array)
 ///
+/// # Note
+///
+/// TOML is not supported for multi-record operations. The TOML specification
+/// requires the root to be a table, so a bare array of records is not
+/// representable. Use the single-record TOML functions instead.
 /// # Errors
 ///
 /// Returns an error if the data format is not supported for multiple records,

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,8 @@ use std::{fmt::Display, path::Path};
 
 use thiserror::Error;
 
+use crate::Error;
+
 /// Supported data formats for serialization and deserialization.
 ///
 /// This enum represents the various data formats that SerdeIO can handle.
@@ -98,8 +100,6 @@ impl Display for DataFormat {
         }
     }
 }
-
-use crate::Error;
 
 /// Resolves the effective data format, inferring it from the file extension
 /// when `data_format` is `DataFormat::Auto`.

--- a/src/types.rs
+++ b/src/types.rs
@@ -61,7 +61,7 @@ impl TryFrom<&str> for DataFormat {
             #[cfg(feature = "yaml")]
             "yaml" | "yml" => Ok(DataFormat::Yaml),
             #[cfg(feature = "messagepack")]
-            "msgpack" | "mpack" | "mpk" => Ok(DataFormat::MessagePack),
+            "msgpack" | "mpack" | "mpk" | "messagepack" => Ok(DataFormat::MessagePack),
             #[cfg(feature = "toml")]
             "toml" => Ok(DataFormat::Toml),
             _ => Err(DataFormatError::Unknown(value.to_string())),
@@ -99,6 +99,21 @@ impl Display for DataFormat {
     }
 }
 
+use crate::Error;
+
+/// Resolves the effective data format, inferring it from the file extension
+/// when `data_format` is `DataFormat::Auto`.
+pub(crate) fn resolve_format(
+    path: impl AsRef<Path>,
+    data_format: DataFormat,
+) -> Result<DataFormat, Error> {
+    if data_format == DataFormat::Auto {
+        Ok(DataFormat::try_from(path.as_ref())?)
+    } else {
+        Ok(data_format)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::convert::TryFrom;
@@ -132,6 +147,10 @@ mod test {
             );
             assert_eq!(
                 DataFormat::try_from("mpk").unwrap(),
+                DataFormat::MessagePack
+            );
+            assert_eq!(
+                DataFormat::try_from("messagepack").unwrap(),
                 DataFormat::MessagePack
             );
         }

--- a/src/write.rs
+++ b/src/write.rs
@@ -82,11 +82,6 @@ pub fn write_record_to_writer<T: Serialize>(
 /// - YAML (requires `yaml` feature, as an array)
 /// - MessagePack (requires `messagepack` feature, as an array)
 ///
-/// # Note
-///
-/// TOML is not supported for multi-record operations. The TOML specification
-/// requires the root to be a table, so a bare array of records is not
-/// representable. Use the single-record TOML functions instead.
 /// # Errors
 ///
 /// Returns an error if the data format is not supported for multiple records,
@@ -115,6 +110,12 @@ pub fn write_record_to_writer<T: Serialize>(
 /// let json = String::from_utf8(buffer).unwrap();
 /// assert!(json.contains("Alice") && json.contains("Bob"));
 /// ```
+///
+/// # Note
+///
+/// TOML is not supported for multi-record operations. The TOML specification
+/// requires the root to be a table, so a bare array of records is not
+/// representable. Use the single-record TOML functions instead.
 pub fn write_records_to_writer<'a, T: Serialize + 'a>(
     writer: impl Write,
     records: impl IntoIterator<Item = &'a T>,

--- a/src/write.rs
+++ b/src/write.rs
@@ -6,16 +6,10 @@ use std::{
 
 use serde::Serialize;
 
-use crate::{Error, backend, types::DataFormat};
-
-fn resolve_format(path: impl AsRef<Path>, data_format: DataFormat) -> Result<DataFormat, Error> {
-    let path_ref = path.as_ref();
-    if data_format == DataFormat::Auto {
-        Ok(DataFormat::try_from(path_ref)?)
-    } else {
-        Ok(data_format)
-    }
-}
+use crate::{
+    Error, backend,
+    types::{DataFormat, resolve_format},
+};
 
 fn create_buf_writer(path: impl AsRef<Path>) -> Result<BufWriter<File>, Error> {
     let file = File::create(path.as_ref())?;
@@ -88,6 +82,11 @@ pub fn write_record_to_writer<T: Serialize>(
 /// - YAML (requires `yaml` feature, as an array)
 /// - MessagePack (requires `messagepack` feature, as an array)
 ///
+/// # Note
+///
+/// TOML is not supported for multi-record operations. The TOML specification
+/// requires the root to be a table, so a bare array of records is not
+/// representable. Use the single-record TOML functions instead.
 /// # Errors
 ///
 /// Returns an error if the data format is not supported for multiple records,


### PR DESCRIPTION
## Summary

Resolve four bugs across serdeio: MessagePack Display→parse round-trip, deduplicate the duplicated `resolve_format` function, fix the json2jsonl example using wrong read API, and document why TOML is unsupported for multi-record operations.

## Background

| Bug | Root Cause | Fix |
|-----|-----------|-----|
| MessagePack round-trip | `DataFormat::MessagePack.to_string()` = `"messagepack"` but `TryFrom<&str>` only accepts `msgpack|mpack|mpk` — Display→parse round-trip fails | Add `"messagepack"` as a parse alias |
| Deduplicate `resolve_format` | Byte-identical `resolve_format` in both `src/read.rs` and `src/write.rs` — maintenance hazard | Hoist to `src/types.rs` (owns `DataFormat`), delete both copies |
| json2jsonl example | `read_record_from_file` (single-record API) used for multi-record read; works for `.json` arrays by accident, fails on `.jsonl`/`.csv` with `UnsupportedFormat` | Switch to `read_records_from_file` |
| TOML multi-record doc | `write_records_to_writer` has no `Toml` arm; TOML requires table root, `toml::to_string(&Vec<Struct>)` fails — not cleanly implementable | Document limitation in doc-comments |

## Changes

### MessagePack round-trip (`src/types.rs`)
- Add `"messagepack"` as a `TryFrom<&str>` alias alongside `msgpack`/`mpack`/`mpk`
- Regression test: `DataFormat::try_from("messagepack") == MessagePack`

### Deduplicate `resolve_format` (`src/types.rs`, `src/read.rs`, `src/write.rs`)
- Add `pub(crate) fn resolve_format` to `src/types.rs` (single source of truth)
- Delete private `resolve_format` from `src/read.rs` and `src/write.rs`
- Update imports: both modules pull `resolve_format` from `crate::types`

### json2jsonl example (`examples/json2jsonl.rs`)
- Replace `read_record_from_file` with `read_records_from_file`
- Adjust call site: returns `Vec<User>` instead of `User`

### TOML multi-record documentation (`src/read.rs`, `src/write.rs`)
- Add `# Note` section to `read_records_from_reader` and `write_records_to_writer` doc-comments explaining why TOML is unsupported for multi-record operations

### Chore
- Add tool artifact directories (`.codegraph/`, `.plan/`, `.todos/`) to `.gitignore`

## Trade-offs
- `resolve_format` placed in `types.rs` (owns `DataFormat`) rather than a new module — avoids over-engineering 8 lines
- Documentation-only fix for TOML multi-record — a real implementation is impossible (toml rejects bare `Vec<Struct>`); a wrapper hack (`{records:[...]}`) was rejected as non-standard and round-trip-breaking